### PR TITLE
remove dh-cmake as a build-depends

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt update -y
-        sudo apt install devscripts ninja-build build-essential cmake dh-cmake
+        sudo apt install devscripts ninja-build build-essential cmake
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
     - name: install deps
       run: |
         sudo apt update -y
-        sudo apt install devscripts ninja-build build-essential cmake
+        sudo apt install devscripts ninja-build build-essential cmake debhelper
 
     - name: Setup Ccache
       uses: hendrikmuhs/ccache-action@main

--- a/duckdb-0.10.0/debian/control
+++ b/duckdb-0.10.0/debian/control
@@ -2,7 +2,7 @@ Source: duckdb
 Section: database
 Priority: optional
 Maintainer: DuckDB Labs <quack@duckdb.org>
-Build-Depends: ninja-build, git, g++ (>= 5.0), cmake (>= 3.15), dh-cmake, dh-cmake-compat (= 1), dh-sequence-cmake, debhelper (>= 11)
+Build-Depends: ninja-build, git, g++ (>= 5.0), cmake (>= 3.15), debhelper (>= 11)
 Homepage: https://duckdb.org
 Standards-Version: 4.6.0.1
 Vcs-Git: https://github.com/Mause/duckdb_ppa.git


### PR DESCRIPTION
i don't think we actually use it
